### PR TITLE
Fixed bug with flame and bullet animation.

### DIFF
--- a/untitled-sdl-tank-game/Game.cpp
+++ b/untitled-sdl-tank-game/Game.cpp
@@ -513,12 +513,20 @@ void Game::mainLoop()
         }
 
         for (bulletIt = bullets.begin();bulletIt != bullets.end(); ++bulletIt) {
-            (*bulletIt).display(renderer, this);
+            (*bulletIt).myTex.render(renderer,
+                getPosXOnScreen((*bulletIt).posX),
+                getPosYOnScreen((*bulletIt).posY),
+                MyTexture::RENDER_IN_CENTER,
+                (*bulletIt).getDirectionAngle());
+
         }
 
         for (flameIt = flames.begin(); flameIt != flames.end(); ++flameIt) {
-            Flame &flame = (*flameIt);
-            flame.display(renderer, this);
+            Flame &flame = (*flameIt);    
+			flame.myTex.renderAnim(renderer,
+                getPosXOnScreen(flame.posX),
+                getPosYOnScreen(flame.posY),
+                MyTexture::RENDER_IN_CENTER, 5, flame.texFrame);
         }
 
         for (bricksIt = bricks.begin(); bricksIt != bricks.end(); ++bricksIt) {

--- a/untitled-sdl-tank-game/untitled-sdl-tank-game.vcxproj
+++ b/untitled-sdl-tank-game/untitled-sdl-tank-game.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{c9010400-c373-47b2-9341-8a33c0ba718f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>untitled_sdl_tank_game</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Issue number: #15.
Back to previous version, f.ex.:
```cpp
       for (flameIt = flames.begin(); flameIt != flames.end(); ++flameIt) {
            Flame &flame = (*flameIt);    
			flame.myTex.renderAnim(renderer,
                getPosXOnScreen(flame.posX),
                getPosYOnScreen(flame.posY),
                MyTexture::RENDER_IN_CENTER, 5, flame.texFrame);
        }
```